### PR TITLE
Fix various README typos and errors

### DIFF
--- a/step-by-step/.vscode/settings.json
+++ b/step-by-step/.vscode/settings.json
@@ -10,7 +10,8 @@
     "08-ledger-ready-gumball-machine/Cargo.toml",
     "09-hello-token-front-end/scrypto-package/Cargo.toml",
     "10-gumball-machine-front-end/scrypto-package/Cargo.toml",
-    "11-hello-non-fungible/Cargo.toml"
+    "11-hello-non-fungible/Cargo.toml",
+    "12-candy-store/Cargo.toml",
   ],
   "cSpell.words": [
     "accesscontroller",

--- a/step-by-step/04-gumball-machine/README.md
+++ b/step-by-step/04-gumball-machine/README.md
@@ -1,4 +1,4 @@
-# 4 Build a Gumball Machine
+# 4. Build a Gumball Machine
 
 A Radix favorite, this example covers the creation of a simple gumball machine,
 which allows users to purchase a gumball in exchange for XRD.

--- a/step-by-step/05-gumball-machine-with-owner/README.md
+++ b/step-by-step/05-gumball-machine-with-owner/README.md
@@ -1,4 +1,4 @@
-# 5 Gumball Machine with an Owner
+# 5. Gumball Machine with an Owner
 
 This example builds on top of the previous Gumball Machine example. In this one
 we add an owner to the gumball machine. Once we have an owner we can provided a

--- a/step-by-step/06-refillable-gumball-machine/README.md
+++ b/step-by-step/06-refillable-gumball-machine/README.md
@@ -1,4 +1,4 @@
-# 6 Refillable Gumball Machine
+# 6. Refillable Gumball Machine
 
 Building on the previous Gumball Machine with an Owner example, in this one
 we'll modify our first behaviour and give the machine the ability to mint more

--- a/step-by-step/07-gumball-machine-transaction-manifests/README.md
+++ b/step-by-step/07-gumball-machine-transaction-manifests/README.md
@@ -1,4 +1,4 @@
-# 7 Gumball Machine Transaction Manifests
+# 7. Gumball Machine Transaction Manifests
 
 In this example there are no changes to the previous blueprint. Instead we focus
 on transaction manifests, what they do and how to use them.

--- a/step-by-step/08-ledger-ready-gumball-machine/README.md
+++ b/step-by-step/08-ledger-ready-gumball-machine/README.md
@@ -1,4 +1,4 @@
-# 8 A Ledger Ready Gumball Machine
+# 8. A Ledger Ready Gumball Machine
 
 In the previous example we allowed our gumball machine to mint its own gumballs.
 The blueprint still isn't quite ready for us to publish on the ledger though.

--- a/step-by-step/09-hello-token-front-end/README.md
+++ b/step-by-step/09-hello-token-front-end/README.md
@@ -1,4 +1,4 @@
-# 9 Hello Token Front End dApp
+# 9. Hello Token Front End dApp
 
 This example shows you how to make a very simple dapp with a front end. In the
 last example we deployed a package to the network and started interacting with

--- a/step-by-step/10-gumball-machine-front-end/README.md
+++ b/step-by-step/10-gumball-machine-front-end/README.md
@@ -229,11 +229,11 @@ already deployed it and have the package address you can skip to
     cd official-examples/step-by-step/10-gumball-machine-front-end
     ```
 
-2.  From inside the `scrypto` directory, build the code: `scrypto build`
+2.  From inside the `scrypto-package` directory, build the code: `scrypto build`
 3.  Two important files (`refillable_gumball_machine.rpd` and
     `refillable_gumball_machine.wasm`) will be generated in
-    `scrypto/target/wasm32-unknown-unknown/release/`. You will need them for the
-    next step.
+    `scrypto-package/target/wasm32-unknown-unknown/release/`. You will need them
+    for the next step.
 
 ##### Deploy the package to Stokenet:
 

--- a/step-by-step/10-gumball-machine-front-end/README.md
+++ b/step-by-step/10-gumball-machine-front-end/README.md
@@ -1,4 +1,4 @@
-# 10 Gumball Machine Front End dApp
+# 10. Gumball Machine Front End dApp
 
 In the previous example we looked at the basics of how to create a dApp with a
 simple front end. In this one we'll take this further by applying the same
@@ -78,7 +78,7 @@ CALL_METHOD
   Address("${accountAddress}")
   "deposit_batch"
   Expression("ENTIRE_WORKTOP")
-;`
+;`;
 ```
 
 (You can also see that we've used our owner badge in this manifest, to pass the

--- a/step-by-step/11-hello-non-fungible/README.md
+++ b/step-by-step/11-hello-non-fungible/README.md
@@ -60,9 +60,9 @@ the `ResourceBuilder` method used from `new_fungible` to
   let my_bucket: Bucket = ResourceBuilder::new_ruid_non_fungible(OwnerRole::None)
 ```
 
-> Non-fungible `ResourceBuilder` methods include
-> `new_integer_non_fungible`,`new_string_non_fungible` and
-> `new_bytes_non_fungible`.
+> **Note:** Non-fungible `ResourceBuilder` methods include
+> `new_ruid_non_fungible`, `new_integer_non_fungible`,`new_string_non_fungible`
+> and `new_bytes_non_fungible`.
 
 For clarity we also change the metadata so we have a new name an symbol for our
 resource.
@@ -93,15 +93,22 @@ struct.
   )
 ```
 
-> To specify a `NonFungibleLocalID` for non RUID local ID types, when minting
-> add `NonFungibleLocalID::` followed by the type and value in a tuple before
-> the `NonFungibleData`. e.g.
+> **Note:** A `NonFungibleLocalID` must be specified for a **non-RUID**
+> non-fungible (integer, string or bytes) when minting. To do this state the
+> local ID before the `NonFungibleData` in a tuple. e.g. if we create our
+> non-fungibles with integer local IDs like so:
+>
+> ```rust
+> let my_bucket: Bucket = ResourceBuilder::new_integer_non_fungible(OwnerRole::None)
+> ```
+>
+> Then we would mint like this:
 >
 > ```rust
 >   .mint_initial_supply([
 >     (
 >       // NonFungibleLocalID
->       NonFungibleLocalId::integer(1),
+>       IntegerNonFungibleLocalId::new(1),
 >       // NonFungibleData
 >       Greeting {
 >         text: "Hello world!".into(),
@@ -156,7 +163,7 @@ Running the example is much the same as the running the original Hello example:
 5.  Now we can transfer one of the non-fungibles to our account.
 
     ```sh
-    resim call-method <COMPONENT_ADDRESS> free_token <ACCOUNT_ADDRESS>
+    resim call-method <COMPONENT_ADDRESS> free_token
     ```
 
 6.  Finally, we can check the state of our account to see that we now have the
@@ -168,8 +175,9 @@ Running the example is much the same as the running the original Hello example:
 
 Unfortunately resim doesn't yet support showing individual non-fungibles and the
 data on them. You will eventually be able to examine non-fungibles using their
-global resource addresses (resource address followed by the local id).
+global resource addresses (resource address followed by the local id) like so:
 
 ```sh
+# Not yet supported
 resim show <RESOURCE_ADDRESS>:<NON_FUNGIBLE_LOCAL_ID>
 ```

--- a/step-by-step/12-candy-store/README.md
+++ b/step-by-step/12-candy-store/README.md
@@ -1,4 +1,4 @@
-# 12 Candy Store
+# 12. Candy Store
 
 This is a good opportunity to introduce another new blueprint. This time we'll
 create a candy store with two products, candy tokens and chocolate egg


### PR DESCRIPTION
- Standardise numbering in readme titles
- Add candy-store reference to VSCode Rust project settings
- Fix some readme typos
- Fix description of how to add an integer non fungible local ID