### PR TITLE
Update `scrypto-math` deps

### DIFF
--- a/build_examples.sh
+++ b/build_examples.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-tag=bottlenose-9396c507
+# This should match the revision/release used for Radix Engine dependencies
+# in the examples.
+tag="v1.2.0"
 
 fetch_scrypto() {
   if [ ! -d radixdlt-scrypto ] ; then

--- a/scrypto-design-patterns/yield_amm/amm/Cargo.lock
+++ b/scrypto-design-patterns/yield_amm/amm/Cargo.lock
@@ -1301,8 +1301,8 @@ dependencies = [
 
 [[package]]
 name = "scrypto_math"
-version = "0.5.0"
-source = "git+https://github.com/lrubasze/scrypto-math?rev=a9bacca#a9bacca949dab2727e32015596a7e3e01983d2ea"
+version = "0.6.0"
+source = "git+https://github.com/ociswap/scrypto-math?tag=v0.6.0#ade7f4d381be232afee3f254810163cf989139d6"
 dependencies = [
  "num-traits",
  "pretty_assertions",

--- a/scrypto-design-patterns/yield_amm/amm/Cargo.toml
+++ b/scrypto-design-patterns/yield_amm/amm/Cargo.toml
@@ -6,8 +6,7 @@ resolver = "2"
 
 [dependencies]
 scrypto = { version = "1.2.0" }
-# TODO: Replace with official scrypto_math dependency when updated
-scrypto_math = { git = "https://github.com/lrubasze/scrypto-math", rev = "a9bacca" }
+scrypto_math = { git = "https://github.com/ociswap/scrypto-math", tag = "v0.6.0" }
 
 [dev-dependencies]
 scrypto-test = { version = "1.2.0" }


### PR DESCRIPTION
Changes:
- Switch back to Ociswap's `scrypto-math` v0.6.0 - it finally uses RE v.1.2.0
- Update `radixdlt-scrypto` tag to `v1.2.0` in build_examples.sh
 